### PR TITLE
解析パラメーターをprojectnameごとに指定できるようにした。

### DIFF
--- a/analysis-mpi/script/GK_thcd.sh
+++ b/analysis-mpi/script/GK_thcd.sh
@@ -5,10 +5,10 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 # shellcheck source=/dev/null
 . "$(dirname "$0")/lib/common.sh"
 
-while read -r task
+while read -r task fst_run lst_run
 do
     init_dir_result "$task" 'GK_thcd'
     cd "$task/Analysis"
     pwd
-    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/GK_thcd.out" <<< "$FST_RUN $LST_RUN" > /dev/null
-done < <(gen_task_list)
+    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/GK_thcd.out" <<< "$fst_run $lst_run" > /dev/null
+done < <(gen_task_and_run_range)

--- a/analysis-mpi/script/GK_viscousity.sh
+++ b/analysis-mpi/script/GK_viscousity.sh
@@ -5,10 +5,10 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 # shellcheck source=/dev/null
 . "$(dirname "$0")/lib/common.sh"
 
-while read -r task
+while read -r task fst_run lst_run
 do
     init_dir_result "$task" 'GK_viscousity'
     cd "$task/Analysis"
     pwd
-    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/GK_viscousity.out" <<< "$FST_RUN $LST_RUN" > /dev/null
-done < <(gen_task_list)
+    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/GK_viscousity.out" <<< "$fst_run $lst_run" > /dev/null
+done < <(gen_task_and_run_range)

--- a/analysis-mpi/script/gr.sh
+++ b/analysis-mpi/script/gr.sh
@@ -5,10 +5,10 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 # shellcheck source=/dev/null
 . "$(dirname "$0")/lib/common.sh"
 
-while read -r task
+while read -r task fst_run lst_run
 do
     init_dir_result "$task" 'gr'
     cd "$task/Analysis"
     pwd
-    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/gr.out" <<< "$FST_RUN $LST_RUN" > /dev/null
-done < <(gen_task_list)
+    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/gr.out" <<< "$fst_run $lst_run" > /dev/null
+done < <(gen_task_and_run_range)

--- a/analysis-mpi/script/lib/common.sh
+++ b/analysis-mpi/script/lib/common.sh
@@ -7,20 +7,34 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 
 DIR_ROOT="$(cd "$(dirname "$0")/.."; pwd)"
 readonly DIR_BUILD="${DIR_ROOT}/build"
-readonly FILE_TARGET_PROJECTS="${DIR_ROOT}/../setting/target_projects.txt"
+readonly FILE_TARGET_PROJECTS="${DIR_ROOT}/../setting/target_projects.tsv"
 
 # .envファイルで設定されている変数に読み取りのみの属性を付加
 readonly DIR_PROJECT_PATHS NAME_TARGET_PROJECT
-readonly FST_RUN LST_RAN
-readonly GK_VIS_FST_CALC GK_VIS_LST_CALC
-readonly GK_THCD_FST_CALC GK_THCD_LST_CALC
 readonly NUM_PARA
 
-gen_task_list () {
-    while read -r line
+gen_task_and_run_range () {
+    while read -r line fst_run lst_run
     do
-        cat "${DIR_PROJECT_PATHS}/${line}.txt"
-    done < "${FILE_TARGET_PROJECTS}"
+        xargs -I{} echo "{} $fst_run $lst_run" <"${DIR_PROJECT_PATHS}/${line}.txt"
+    done < <( tail -n +2 "${FILE_TARGET_PROJECTS}" |
+        awk '{print $1,$2,$3}' )
+}
+
+gen_task_and_gk_thcd_range () {
+    while read -r line gk_thcd_fst_calc gk_thcd_lst_calc
+    do
+        xargs -I{} echo "{} $gk_thcd_fst_calc $gk_thcd_lst_calc" <"${DIR_PROJECT_PATHS}/${line}.txt"
+    done < <( tail -n +2 "${FILE_TARGET_PROJECTS}" |
+        awk '{print $1,$4,$5}')
+}
+
+gen_task_and_gk_vis_range () {
+    while read -r line gk_vis_fst_calc gk_vis_lst_calc
+    do
+        xargs -I{} echo "{} $gk_vis_fst_calc $gk_vis_lst_calc" <"${DIR_PROJECT_PATHS}/${line}.txt"
+    done < <( tail -n +2 "${FILE_TARGET_PROJECTS}" |
+        awk '{print $1,$6,$7}')
 }
 
 split_file() {

--- a/analysis-mpi/script/msd.sh
+++ b/analysis-mpi/script/msd.sh
@@ -5,10 +5,10 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 # shellcheck source=/dev/null
 . "$(dirname "$0")/lib/common.sh"
 
-while read -r task
+while read -r task fst_run lst_run
 do
     init_dir_result "$task" 'msd'
     cd "$task/Analysis"
     pwd
-    mpirun -n "$NUM_PARA" "${DIR_ROOT}/build/src/msd.out" <<< "$FST_RUN $LST_RUN" > /dev/null
-done < <(gen_task_list)
+    mpirun -n "$NUM_PARA" "${DIR_ROOT}/build/src/msd.out" <<< "$fst_run $lst_run" > /dev/null
+done < <(gen_task_and_run_range)

--- a/analysis-mpi/script/rmsd.sh
+++ b/analysis-mpi/script/rmsd.sh
@@ -5,10 +5,10 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 # shellcheck source=/dev/null
 . "$(dirname "$0")/lib/common.sh"
 
-while read -r task
+while read -r task fst_run lst_run
 do
     init_dir_result "$task" 'rmsd'
     cd "$task/Analysis"
     pwd
-    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/rmsd.out" <<< "$FST_RUN $LST_RUN" > /dev/null
-done < <(gen_task_list)
+    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/rmsd.out" <<< "$fst_run $lst_run" > /dev/null
+done < <(gen_task_and_run_range)

--- a/analysis-mpi/script/temp.sh
+++ b/analysis-mpi/script/temp.sh
@@ -5,10 +5,10 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 # shellcheck source=/dev/null
 . "$(dirname "$0")/lib/common.sh"
 
-while read -r task
+while read -r task fst_run lst_run
 do  
     init_dir_result "$task" 'temp'
     cd "$task/Analysis"
     pwd
-    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/temp.out" <<< "$FST_RUN $LST_RUN" > /dev/null
-done < <(gen_task_list)
+    mpirun -n "${NUM_PARA}" "${DIR_ROOT}/build/src/temp.out" <<< "$fst_run $lst_run" > /dev/null
+done < <(gen_task_and_run_range)

--- a/analysis-mpi/script/thcd.sh
+++ b/analysis-mpi/script/thcd.sh
@@ -5,11 +5,11 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 # shellcheck source=/dev/null
 . "$(dirname "$0")/lib/common.sh"
 
-while read -r task
+while read -r task gk_thcd_fst_calc gk_thcd_lst_calc
 do
     init_dir_result "$task" 'thcd'
     cd "$task/Analysis"
     pwd
-    "${DIR_ROOT}/build/src/thcd.out" <<< "$GK_THCD_FST_CALC $GK_THCD_LST_CALC" > /dev/null
-    head -n "$GK_THCD_LST_CALC" "$task/Analysis/GK_thcd/integ.txt" | split_file 100 > "$task/Analysis/thcd/integ.txt"
-done < <(gen_task_list)
+    "${DIR_ROOT}/build/src/thcd.out" <<< "$gk_thcd_fst_calc $gk_thcd_lst_calc" > /dev/null
+    head -n "$gk_thcd_lst_calc" "$task/Analysis/GK_thcd/integ.txt" | split_file 100 > "$task/Analysis/thcd/integ.txt"
+done < <(gen_task_and_gk_thcd_range)

--- a/analysis-mpi/script/viscousity.sh
+++ b/analysis-mpi/script/viscousity.sh
@@ -5,11 +5,11 @@ trap 'echo "ERROR: line no = $LINENO, exit status = $?" >&2; exit 1' ERR
 # shellcheck source=/dev/null
 . "$(dirname "$0")/lib/common.sh"
 
-while read -r task
+while read -r task gk_vis_fst_calc gk_vis_lst_calc
 do
     init_dir_result "$task" 'viscousity'
     cd "$task/Analysis"
     pwd
-    "${DIR_ROOT}/build/src/viscousity.out" <<< "$GK_VIS_FST_CALC $GK_VIS_LST_CALC" > /dev/null
-    head -n "$GK_VIS_LST_CALC" "$task/Analysis/GK_viscousity/integ.txt" | split_file 100 > "$task/Analysis/viscousity/integ.txt"
-done < <(gen_task_list)
+    "${DIR_ROOT}/build/src/viscousity.out" <<< "$gk_vis_fst_calc $gk_vis_lst_calc" > /dev/null
+    head -n "$gk_vis_lst_calc" "$task/Analysis/GK_viscousity/integ.txt" | split_file 100 > "$task/Analysis/viscousity/integ.txt"
+done < <(gen_task_and_gk_vis_range)

--- a/setting/.env.sample
+++ b/setting/.env.sample
@@ -1,8 +1,2 @@
 DIR_PROJECT_PATHS=/File-Server/hdd1/abe/diatomic-md/md-diatomic-project-builder/output/project-paths
-FST_RUN=2
-LST_RUN=81
-GK_VIS_FST_CALC=4000
-GK_VIS_LST_CALC=6000
-GK_THCD_FST_CALC=4000
-GK_THCD_LST_CALC=6000
 NUM_PARA=12


### PR DESCRIPTION
why
便利のため

what
いままで.envに書いていた解析用のパラメータ（GK公式の積分範囲など）をプロジェクトごとに個別に指定できるように、target_projects.tsvに記入するように変更。また、target_projects.tsvからタスクを生成する関数を無駄な引数が出ないように関数を分けた。